### PR TITLE
XXE vulnerability fix for JDK7+

### DIFF
--- a/src/main/java/org/simpleframework/xml/stream/DocumentProvider.java
+++ b/src/main/java/org/simpleframework/xml/stream/DocumentProvider.java
@@ -23,6 +23,7 @@ import java.io.Reader;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
@@ -54,6 +55,15 @@ class DocumentProvider implements Provider {
    public DocumentProvider() {
       this.factory = DocumentBuilderFactory.newInstance();
       this.factory.setNamespaceAware(true);
+      //XXE fix
+      //NOTE: only jre7_u67+ and jre8_20+
+      this.factory.setXIncludeAware(false);
+      this.factory.setExpandEntityReferences(false);
+     
+      this.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+      this.setFeature("http://xml.org/sax/features/external-general-entities", false);
+      this.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+      this.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
    }
    
    /**
@@ -97,5 +107,13 @@ class DocumentProvider implements Provider {
       Document document = builder.parse(source);
       
       return new DocumentReader(document);   
+   }
+   
+   private void setFeature(String feature, boolean flag) {
+      try{
+         this.factory.setFeature(feature, flag);
+      }catch (ParserConfigurationException e){
+         //Unsuporrted
+      } 
    }
 }

--- a/src/main/java/org/simpleframework/xml/stream/StreamProvider.java
+++ b/src/main/java/org/simpleframework/xml/stream/StreamProvider.java
@@ -50,6 +50,9 @@ class StreamProvider implements Provider {
     */
    public StreamProvider() {
       this.factory = XMLInputFactory.newInstance();
+      //XXE fix
+      this.factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+      this.factory.setProperty("javax.xml.stream.isSupportingExternalEntities", false);
    }
 
    /**


### PR DESCRIPTION
Disabled DTD support in StreamProvider and DocumentProvider.
For more info check link below:
[https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Prevention_Cheat_Sheet#JAXP_DocumentBuilderFactory.2C_SAXParserFactory_and_DOM4J
](XXE)